### PR TITLE
Minor doc fixes

### DIFF
--- a/src/ConfIDent_schema/schema/ConfIDent_schema.yaml
+++ b/src/ConfIDent_schema/schema/ConfIDent_schema.yaml
@@ -343,7 +343,7 @@ classes:
 # plan specs
   EventFormatSpecification:
     class_uri: aeon:0000004
-    title: Subobject Event Format
+    title: Event Format
     description: >-
       An academic event format specification is a plan specification that classifies a planned gathering of people in an academic context according to some sociocultural format, which provides implicit and explicit details on how this gathering is to be carried out by its participants in terms of achieving certain objectives, fulfilling certain conditions and performing certain actions. It thus concretizes the expectations of the contributors of an academic event.
       While the explicit details are often provided as concrete parts (e.g. deadline or attendance fee specifications), the implicit details depend on the semantics encoded in the words used for the classification of academic events (e.g. "conference" or "workshop"). Depending on the sociocultural background these classifications can overlap or vary to a certain degree.
@@ -358,7 +358,7 @@ classes:
         required: true
         range: string
   Deadline:
-    title: Subobject Deadline
+    title: Deadline
     description: A container for event deadlines.
     slots:
       - type
@@ -380,7 +380,7 @@ classes:
         required: true
 # Metrics
   Metric:
-    title: Subobject Metric
+    title: Metric
     description: A container for statistical information about an event or event series.
     attributes:
       int_value:
@@ -426,7 +426,7 @@ classes:
               required: true
 # location
   Location:
-    title: Subobject Location
+    title: Location
     description: A container for the information about the location in which an academic event takes place.
     attributes:
       has_city:
@@ -496,7 +496,7 @@ classes:
         range: string
 # descriptors
   AcademicField:
-    title: Subobject Academic Field
+    title: Academic Field
     mixins:
       - SchemaBasedThing
     description: An academic field is the scientific subject of an event or event series according to some controlled vocabulary or thesaurus and as such requires the scheme URI.
@@ -506,7 +506,7 @@ classes:
         range: string
         required: true
   Context:
-    title: Subobject Context
+    title: Context
     description: A container to provide extra information, such as call of papers event description.
     attributes:
       text:
@@ -523,7 +523,7 @@ classes:
         range: uriorcurie
 # contributors
   Contributor:
-    title: Subobject Contributor
+    title: Contributor
     description: A contributor is a person or organization that holds a contributor role which is being realized in an event or event series.
     mixins:
       - NamedThing
@@ -538,23 +538,23 @@ classes:
         description: The internal ConfIDent identifier for a contibutor
 
   Sponsor:
-    title: Subobject Sponsor
+    title: Sponsor
     is_a: Contributor
     description: A person or an organization whose role it is to sponsor an academic event or event series.
   Attendee:
-    title: Subobject Attendee
+    title: Attendee
     is_a: Contributor
     description: A person whose only role it is to attend an academic event.
   Moderator:
-    title: Subobject Moderator
+    title: Moderator
     is_a: Contributor
     description: A person that has the role to moderate an academic event.
   Reviewer:
-    title: Subobject Reviewer
+    title: Reviewer
     is_a: Contributor
     description: A person that has the role to review the submissions of an academic event.
   Organizer:
-    title: Subobject Organizer
+    title: Organizer
     is_a: Contributor
     description: An organizer of an academic event or event series.
     attributes:
@@ -566,7 +566,7 @@ classes:
         required: false
         recommended: true
   ContactPerson:
-    title: Subobject Contact Person
+    title: Contact Person
     description: The contact person of an academic event or event series.
     is_a: Organizer
     attributes:
@@ -582,24 +582,24 @@ classes:
         description: The telephone number of the contact person.
         range: string
   CommitteeMember:
-    title: Subobject Committee Member
+    title: Committee Member
     is_a: Organizer
     description: A members of an academic event committee.
   CommitteeChair:
-    title: Subobject Committee Chair
+    title: Committee Chair
     is_a: CommitteeMember
     description: The head of an academic event committee.
   Presenter:
-    title: Subobject Presenter
+    title: Presenter
     is_a: Contributor
     description: A person that presents its work at an academic event.
   KeynoteSpeaker:
-    title: Subobject Keynote Speaker
+    title: Keynote Speaker
     is_a: Presenter
     description: A 'keynote speaker' is a presenter that is an invited person - often a multiplier in his or her (research) field - responsible for delivering a keynote speech.
 # output
   Publication:
-    title: Subobject Publication
+    title: Publication
     description: A published work, e.g. proceedings or conferenc paper, that is the output of an academic event or series.
     mixins:
       - NamedThing
@@ -629,7 +629,7 @@ classes:
         inlined_as_list: true
 # mixins
   SchemaBasedThing:
-    title: Subobject Schema Based Thing
+    title: Schema Based Thing
     description: A mixin used in classes that contain schema based values, such as the classifications used to denote the academic field of an event or the external identifiers used to denote a thing.
     mixin: true
     slots:
@@ -637,7 +637,7 @@ classes:
       - schema_name
       - schema_base_uri
   NamedThing:
-    title: Subobject Named Thing
+    title: Named Thing
     description: A mixin used to provide the attributes needed for the identification of a thing.
     mixin: true
     slots:

--- a/src/ConfIDent_schema/schema/ConfIDent_schema.yaml
+++ b/src/ConfIDent_schema/schema/ConfIDent_schema.yaml
@@ -12,7 +12,7 @@ prefixes:
   skos: http://www.w3.org/2004/02/skos/core#
   sdo: https://schema.org/
   confident: https://raw.githubusercontent.com/TIBHannover/ConfIDent_schema/main/src/linkml/confident_schema.yaml#
-  aeon: https://github.com/tibonto/aeon#AEON_
+  AEON: http://purl.obolibrary.org/obo/AEON_
   OBI: http://purl.obolibrary.org/obo/OBI_
   IAO: http://purl.obolibrary.org/obo/IAO_
   BFO: http://purl.obolibrary.org/obo/BFO_
@@ -31,9 +31,9 @@ prefixes:
 default_prefix: confident
 default_range: string
 imports:
- - linkml:types
+  - linkml:types
 emit_prefixes:
-  - aeon
+  - AEON
   - confident
   - sdo
 
@@ -45,7 +45,7 @@ classes:
   EventSeries:
     description: |-
       An academic event series describes the set of academic events which take place on a regular basis and thus have an established common identity. This identity is constituted, for example, through institutional continuity in the hosting of a series (e.g. by a specialised society), thematic focuses and/or a common label under which a series is defined (particularly name and acronym). Nevertheless, it is possible that each of these criteria may change over time.
-    class_uri: aeon:0000002
+    class_uri: AEON:0000002
     title: Event Series
     slots:
     # required
@@ -145,7 +145,7 @@ classes:
       - sdo:EventSeries
 # Event
   Event:
-    class_uri: aeon:0000001
+    class_uri: AEON:0000001
     description: |-
       An academic event is part of the established instruments of science communication as a format for conveying the latest scientific publications. It is defined by the meeting of researchers at a specific time and place (virtual or physical) and with a specific thematic focus to present, hear and discuss these publications. In contrast to other forms of events, academic events should primarily serve the exchange of results and methods of scientific research and their didactic mediation.  Furthermore, a significant participation of scientific organizations in the realization of an academic event is constitutive for this type of event; for example, to distinguish it from events in which researchers mainly act as external experts or with a purely legitimising function.
     title: Event
@@ -342,7 +342,7 @@ classes:
         ifabsent: uri(http://www.wikicfp.com/cfp/program?id=$1)
 # plan specs
   EventFormatSpecification:
-    class_uri: aeon:0000004
+    class_uri: AEON:0000004
     title: Event Format
     description: >-
       An academic event format specification is a plan specification that classifies a planned gathering of people in an academic context according to some sociocultural format, which provides implicit and explicit details on how this gathering is to be carried out by its participants in terms of achieving certain objectives, fulfilling certain conditions and performing certain actions. It thus concretizes the expectations of the contributors of an academic event.
@@ -740,7 +740,7 @@ slots:
   academic_field:
     title: Academic Field
     description: A property to describe the scientific subject(s) of an event or event series, according to some controlled vocabulary or thesaurus. If this is used, its subproperties [Schema Value](schema_value.md) and [Schema Name](schema_name.md) are mandatory.
-    slot_uri: aeon:0000040
+    slot_uri: AEON:0000040
     range: AcademicField
     multivalued: true
     inlined_as_list: true
@@ -866,18 +866,18 @@ slots:
     description: The start date of an academic event or event series. Wheres the latter will in reality most likely be the start date of the first event of this series, unless there is some other source from which it is possible to derive the date of the inception of the series.
     range: datetime
     required: true
-    slot_uri: aeon:start_date
+    slot_uri: AEON:start_date
   end_date:
     title: End Date
     description: Similar to start_date but only for the end of an academic event or event series.
     range: datetime
     required: true
-    slot_uri: aeon:end_date
+    slot_uri: AEON:end_date
   event_status:
     title: Event Status
     description: A property to provide the status of an event from a controlled list (e.g. as scheduled (default), postpooned, canceld etc).
     required: true
-    slot_uri: aeon:event_status
+    slot_uri: AEON:event_status
     range: EventStatus
     ifabsent: string(as scheduled)
 # recommended Event slots
@@ -905,7 +905,7 @@ slots:
   event_format:
     title: Event Format
     description: A property to provide an event format specification, if none of the [Event Types](EventType.md) are applicable to specify the format of an academic event.
-    slot_uri: aeon:0000032
+    slot_uri: AEON:0000032
     range: EventFormatSpecification
     required: false
     recommended: true
@@ -928,7 +928,7 @@ slots:
   ordinal:
     title: Ordinal
     description: The ordnial number of an academic event within its series.
-    slot_uri: aeon:event_number
+    slot_uri: AEON:event_number
     range: integer
     required: false
     recommended: false
@@ -985,63 +985,63 @@ enums:
         description: >-
           A colloquium is an academic meeting that usually lasts only a few hours and serves to discuss a specific topic. Colloquia are usually part of the academic exchange in everyday university life with only one speaker, but can also take place on special occasions (anniversaries, start or end of the lecture phase, etc.) and can have more than one speaker.
         title: Colloquium
-        meaning: aeon:0000101
+        meaning: AEON:0000101
       Conference:
         description: >-
           A conference is an academic event that lasts up to several days and serves as a forum for presentations on a specific topic or subject area. In addition to subject-specific conferences, there are also interdisciplinary conferences which allow both a broader focus and more specific questions on a particular (academic) problem. Conferences often have a highly formalized structure of parallel, clearly defined sessions with several short presentations and plenary sessions with invited (keynote) speakers who are considered multipliers in their (research) field. Ideally, the selection of the speakers and their contributions is subject to a review process.
-        meaning: aeon:0000103
+        meaning: AEON:0000103
       Congress:
         description: >-
           A congress is a certain type of conference which is characterised by a larger number of participants (often several hundred) and is oftentimes organised jointly by large, established (e.g. specialised societies) and/or several institutions. Congresses have a broader thematic focus than simple conferences, take place in certain cycles, but can still target an exclusive group of participants (e.g. representatives of a single discipline).
-        meaning: aeon:0000123
+        meaning: AEON:0000123
       Session:
         description: >-
           A session is a clearly defined part of a academic event in which a small number of speakers (usually 2-5) focus on a specific topic. A session is usually formally accompanied by a session chair, who assumes the function of a moderator.
-        meaning: aeon:0000111
+        meaning: AEON:0000111
       Poster Session:
         description: >-
           A poster session is a session at which poster papers are presented.
-        meaning: aeon:0000127
+        meaning: AEON:0000127
       Talk:
         description: >-
           A talk is a central part of a larger academic event, at which a specific topic is being presented in a rather short way.
-        meaning: aeon:0000125
+        meaning: AEON:0000125
       Keynote Speech:
         description: >-
           A keynote speech is a special talk that has the function to set the underlying tone and summarize the core message or most important revelation of the academic event at which it is given.
-        meaning: aeon:00001115
+        meaning: AEON:00001115
       Event Track:
         description: >-
           An academic event that, as a part of a larger academic event, has the function to group even smaller parts of the academic event, like sessions and talks, according to a shared theme or topic. It usually has dedicated chairs and program committees.
-        meaning: aeon:00001117
+        meaning: AEON:00001117
       Forum:
         description: >-
           An academic event whose sociocultural format is determined in an academic event type specification that classifies the academic event as a forum.
-        meaning: aeon:0000105
+        meaning: AEON:0000105
       Hackathon:
         description: >-
           A hackathon is a gathering of software developers with the goal to develop software collaboratively in a short timeframe.
-        meaning: aeon:0000107
+        meaning: AEON:0000107
       Seminar:
         description: >-
           A seminar can serve as a term for older conference series, but in current usage the term mainly describes a specific teaching format that serves to develop content and provides space for discussion. Participation from the audience is usually encouraged.
-        meaning: aeon:0000109
+        meaning: AEON:0000109
       Symposium:
         description: >-
           A symposium is a specific type of conference with a narrower thematic focus, with fewer participants and of shorter duration. The degree of structuring lies between a classic conference and a workshop, allows more discussion than the larger conference, but is usually more formalized than the workshop.
-        meaning: aeon:0000113
+        meaning: AEON:0000113
       Tutorial:
         description: >-
           An academic event that has the function to educate the audience on a certain topic. A tutorial is often realized as an academic event talk or academic event session.
-        meaning: aeon:0000119
+        meaning: AEON:0000119
       Workshop:
         description: >-
           Workshops are smaller academic events that serve to exchange information on a specific topic or problem. They usually last one or two days and offer space for discussion and the development of content and solutions. Group work is often part of the event concept.
-        meaning: aeon:0000121
+        meaning: AEON:0000121
       other:
         description: >-
           This value is to be used if the event format cannot be represented using one of the other permissible values defined in the [Event Type](EventType.md) enum. If this value is chosen the use of [Other Event Format](other_format.md) is mandatory.
-        meaning: aeon:0000001
+        meaning: AEON:0000001
 # event status
   EventStatus:
     title: Event Status
@@ -1073,23 +1073,23 @@ enums:
     description: An enum that specifies the possible kinds of deadlines of an academic event.
     permissible_values:
       submission deadline:
-        meaning: aeon:0000067
+        meaning: AEON:0000067
       notification deadline:
-        meaning: aeon:0000064
+        meaning: AEON:0000064
       abstract deadline:
-        meaning: aeon:0000061
+        meaning: AEON:0000061
       camera-ready deadline:
-        meaning: aeon:0000062
+        meaning: AEON:0000062
       demo deadline:
-        meaning: aeon:0000063
+        meaning: AEON:0000063
       paper deadline:
-        meaning: aeon:0000065
+        meaning: AEON:0000065
       poster deadline:
-        meaning: aeon:0000066
+        meaning: AEON:0000066
       tutorial deadline:
-        meaning: aeon:0000068
+        meaning: AEON:0000068
       workshop deadline:
-        meaning: aeon:0000069
+        meaning: AEON:0000069
       other:
         description: This value is to be used, if the other allowed values are not applicable.
 # metric type


### PR DESCRIPTION
This PR deletes the "Subobject" from the titles of some classes, as this was just intended as a type hint for SMW implementation, which is not needed anymore. It also updates the AEON prefix use in the schema.